### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "gameservices",
     "name_pretty": "Game Servers",
     "product_documentation": "https://cloud.google.com/game-servers/",
-    "client_documentation": "https://googleapis.dev/python/gameservices/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/gameservices/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Cloud Game Servers
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-game-servers.svg
    :target: https://pypi.org/project/google-cloud-game-servers/
 .. _Cloud Game Servers: https://cloud.google.com/game-servers/
-.. _Client Library Documentation: https://googleapis.dev/python/gameservices/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/gameservices/latest
 .. _Product Documentation:  https://cloud.google.com/game-servers/
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.