### PR TITLE
fix(deps): remove libcst dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setuptools.setup(
         "proto-plus >= 1.4.0",
     ),
     python_requires=">=3.6",
-    setup_requires=["libcst >= 0.2.5"],
     scripts=["scripts/fixup_keywords.py"],
     classifiers=[
         "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
libcst is only required to run fixup scripts. This library was always generated with the microgenerator, so the fixup scripts are not needed.


